### PR TITLE
Release v1.4.0: device registry removal support

### DIFF
--- a/custom_components/bacnet_hub/__init__.py
+++ b/custom_components/bacnet_hub/__init__.py
@@ -1028,6 +1028,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, entry: ConfigEntry, device_entry: dr.DeviceEntry
+) -> bool:
+    """Allow deleting client devices from the device registry.
+
+    Refused only for the hub device itself (it represents this config entry
+    and is recreated on every setup). Every other device on this entry is a
+    discovered BACnet client: deleting one is always safe - a client that is
+    still on the network simply reappears with its next I-Am / rescan, while
+    stale clients (powered off, renumbered, test devices) finally go away.
+    """
+    for domain, identifier in device_entry.identifiers:
+        if domain != DOMAIN:
+            continue
+        ident = str(identifier)
+        if ident == entry.entry_id or ident.startswith("device-instance-"):
+            return False
+    return True
+
+
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     data = _ensure_domain(hass)
     servers: dict[str, Any] = data[KEY_SERVERS]

--- a/custom_components/bacnet_hub/manifest.json
+++ b/custom_components/bacnet_hub/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "bacnet_hub",
   "name": "BACnet Hub",
-  "version": "1.3.1-beta.143",
+  "version": "1.4.0-beta.145",
   "documentation": "https://github.com/magliaral/ha-bacnet-hub",
   "issue_tracker": "https://github.com/magliaral/ha-bacnet-hub/issues",
   "codeowners": [


### PR DESCRIPTION
## Summary

- Implement `async_remove_config_entry_device`: Home Assistant now offers the **delete** action for devices of this integration.
- The hub device itself is refused (it represents the config entry and is recreated on every setup). All discovered BACnet client devices can be deleted — a client that is still on the network reappears with its next I-Am / rescan, while stale registry entries (powered-off or renumbered devices) can finally be cleaned up.

Field-tested on v1.4.0-beta.145: three stale client devices (an offline Finder Opta and two empty client shells) were removed cleanly from the device registry.

## After merging

HACS -> BACnet Hub -> Redownload -> **v1.4.0**, then restart Home Assistant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)